### PR TITLE
fix: fixed wrong type in openapi doc

### DIFF
--- a/api.swagger.yaml
+++ b/api.swagger.yaml
@@ -3486,9 +3486,7 @@ paths:
           content:
             application/json:
               schema:
-                items:
-                  $ref: '#/components/schemas/StrippedListings'
-                type: array
+                $ref: '#/components/schemas/StrippedListings'
           description: >-
             Facility was found & you were allowed to access it. The result is in
             the body.


### PR DESCRIPTION
This seems to cause issues in client generation when using openapi-generator-cli.
After this change it worked correctly.